### PR TITLE
Fixes for Cyclomatic Complexity calculation

### DIFF
--- a/src/SonarLint.CSharp/Metrics/Metrics.cs
+++ b/src/SonarLint.CSharp/Metrics/Metrics.cs
@@ -102,18 +102,7 @@ namespace SonarLint.Common.CSharp
                         n =>
                             // TODO What about the null coalescing operator?
                             ComplexityIncreasingKinds.Contains(n.Kind()) ||
-                            IsReturnButNotLast(n) ||
                             IsFunctionWithBody(n));
-        }
-        private bool IsReturnButNotLast(SyntaxNode node)
-        {
-            return node.IsKind(SyntaxKind.ReturnStatement) && !IsLastStatement(node);
-        }
-        private bool IsLastStatement(SyntaxNode node)
-        {
-            var nextToken = node.GetLastToken().GetNextToken();
-            return nextToken.Parent.IsKind(SyntaxKind.Block) &&
-                IsFunction(nextToken.Parent.Parent);
         }
 
         private static readonly SyntaxKind[] TriviaKinds =

--- a/src/SonarLint.VisualBasic/Metrics/Metrics.cs
+++ b/src/SonarLint.VisualBasic/Metrics/Metrics.cs
@@ -202,6 +202,7 @@ namespace SonarLint.Common.VisualBasic
             SyntaxKind.DeclareSubStatement,
             SyntaxKind.DeclareFunctionStatement,
             SyntaxKind.SubNewStatement,
+            SyntaxKind.OperatorStatement,
 
             SyntaxKind.IfStatement,
             SyntaxKind.SingleLineIfStatement,
@@ -214,8 +215,7 @@ namespace SonarLint.Common.VisualBasic
             SyntaxKind.ForStatement,
             SyntaxKind.ForEachStatement,
 
-            SyntaxKind.ThrowStatement,
-            SyntaxKind.TryStatement,
+            SyntaxKind.CatchStatement,
 
             SyntaxKind.ErrorStatement,
 
@@ -246,8 +246,6 @@ namespace SonarLint.Common.VisualBasic
             SyntaxKind.ContinueWhileStatement,
 
             SyntaxKind.StopStatement,
-
-            SyntaxKind.ReturnStatement,
 
             SyntaxKind.AndAlsoExpression,
             SyntaxKind.OrElseExpression,

--- a/src/Tests/SonarLint.UnitTest/Common/MetricsTest.cs
+++ b/src/Tests/SonarLint.UnitTest/Common/MetricsTest.cs
@@ -422,8 +422,8 @@ End Class").Should().BeEquivalentTo(1, 2, 3, 4, 5, 6, 7, 8);
             Complexity(AnalyzerLanguage.CSharp, "abstract class MyClass { abstract void MyMethod(); }").Should().Be(0);
             Complexity(AnalyzerLanguage.CSharp, "class MyClass { void MyMethod() { } }").Should().Be(1);
             Complexity(AnalyzerLanguage.CSharp, "class MyClass { void MyMethod() { return; } }").Should().Be(1);
-            Complexity(AnalyzerLanguage.CSharp, "class MyClass { void MyMethod() { return; return; } }").Should().Be(2);
-            Complexity(AnalyzerLanguage.CSharp, "class MyClass { void MyMethod() { { return; } } }").Should().Be(2);
+            Complexity(AnalyzerLanguage.CSharp, "class MyClass { void MyMethod() { return; return; } }").Should().Be(1);
+            Complexity(AnalyzerLanguage.CSharp, "class MyClass { void MyMethod() { { return; } } }").Should().Be(1);
             Complexity(AnalyzerLanguage.CSharp, "class MyClass { void MyMethod() { if (false) { } } }").Should().Be(2);
             Complexity(AnalyzerLanguage.CSharp, "class MyClass { void MyMethod() { if (false) { } else { } } }").Should().Be(2);
             Complexity(AnalyzerLanguage.CSharp, "class MyClass { void MyMethod(int p) { switch (p) { default: break; } } }").Should().Be(2);
@@ -446,8 +446,8 @@ End Class").Should().BeEquivalentTo(1, 2, 3, 4, 5, 6, 7, 8);
             Complexity(AnalyzerLanguage.VisualBasic, "Class MyClass \n End Class").Should().Be(0);
             Complexity(AnalyzerLanguage.VisualBasic, "MustInherit Class MyClass \n Private MustOverride Sub MyMethod() \n End Class").Should().Be(1);
             Complexity(AnalyzerLanguage.VisualBasic, "Class MyClass \n Sub MyMethod() \n End Sub \n End Class").Should().Be(1);
-            Complexity(AnalyzerLanguage.VisualBasic, "Class MyClass \n Sub MyMethod() \n Return \n End Sub \n End Class").Should().Be(2);
-            Complexity(AnalyzerLanguage.VisualBasic, "Class MyClass \n Sub MyMethod() \n Return \n Return \n End Sub \n End Class").Should().Be(3);
+            Complexity(AnalyzerLanguage.VisualBasic, "Class MyClass \n Sub MyMethod() \n Return \n End Sub \n End Class").Should().Be(1);
+            Complexity(AnalyzerLanguage.VisualBasic, "Class MyClass \n Sub MyMethod() \n Return \n Return \n End Sub \n End Class").Should().Be(1);
             Complexity(AnalyzerLanguage.VisualBasic, "Class MyClass \n Sub MyMethod() \n If False Then \n End If \n End Sub \n End Class").Should().Be(2);
             Complexity(AnalyzerLanguage.VisualBasic, "Class MyClass \n Sub MyMethod() \n If False Then \n Else \n End If \n End Sub \n End Class").Should().Be(2);
             Complexity(AnalyzerLanguage.VisualBasic, "Class MyClass \n Sub MyMethod() \n Select Case p \n Case Else \n Exit Select \n End Select \n End Sub \n End Class").Should().Be(2);
@@ -474,15 +474,15 @@ End Class").Should().BeEquivalentTo(1, 2, 3, 4, 5, 6, 7, 8);
             Complexity(AnalyzerLanguage.VisualBasic, "Module Module1\n Class Foo\n Function Bar() \n Return 0\n End Function \n End Class\n End Module").Should().Be(1);
             Complexity(AnalyzerLanguage.VisualBasic,
                 "Module Module1\n Class Foo\n Function Bar() \n If False Then \n Return 1 \n Else \n Return 0 " +
-                "\n End If\n End Function\n End Class\n End Module").Should().Be(4);
-            Complexity(AnalyzerLanguage.VisualBasic, "Module Module1\n Class Foo\n Sub Foo() \n Dim foo = Sub() Return 42\n End Sub\n End Class\n End Module").Should().Be(2);
+                "\n End If\n End Function\n End Class\n End Module").Should().Be(2);
+            Complexity(AnalyzerLanguage.VisualBasic, "Module Module1\n Class Foo\n Sub Foo() \n Dim foo = Sub() Return 42\n End Sub\n End Class\n End Module").Should().Be(1);
             Complexity(AnalyzerLanguage.VisualBasic, "Module Module1\n Class Foo\n ReadOnly Property MyProp \n Get \n Return \"\" \n End Get \n End Property\n End Class\n End Module").Should().Be(0);
             Complexity(AnalyzerLanguage.VisualBasic, "Module Module1\n Class Foo\n Sub Foo() \n Dim Foo = If(True, True, False)\n End Sub\n End Class\n End Module").Should().Be(1);
             Complexity(AnalyzerLanguage.VisualBasic, "Module Module1\n Class Foo\n Sub Foo() \n Dim Foo = Function() 0\n End Sub\n End Class\n End Module").Should().Be(1);
             Complexity(AnalyzerLanguage.VisualBasic,
                 "Module Module1\n Class Foo\n Sub Foo() \n Dim Foo = Function() \n Return False \n " +
                 "End Function\n End Sub\n End Class\n End Module").Should().Be(1);
-            Complexity(AnalyzerLanguage.VisualBasic, "Module Module1\n Class Foo\n Sub Foo() \n Throw New AccessViolationException()\n End Sub\n End Class\n End Module").Should().Be(2);
+            Complexity(AnalyzerLanguage.VisualBasic, "Module Module1\n Class Foo\n Sub Foo() \n Throw New AccessViolationException()\n End Sub\n End Class\n End Module").Should().Be(1);
             Complexity(AnalyzerLanguage.VisualBasic, "Module Module1\n Class Foo\n Sub Foo() \n GoTo Foo\n End Sub\n End Class\n End Module").Should().Be(2);
         }
 


### PR DESCRIPTION
SonarLint doesn't calculate the McCabe Cyclomatic Complexity correctly, because it's counting return statements as well.

Cyclomatic complexity should be equal to **the number of branch points in your code + 1**.

Let's look at some examples, to make clear why the current calculation doesn't make sense.

```
if (expression) {
	// statement 1
}
// statement 2
```
This piece of code has a complexity of 2. While statement 2 is always executed, the complexity is in the fact that statement 1 is sometimes executed and sometimes not.


```
if (expression) {
	// statement 1
} else {
	// statement 2
}
```
This piece of code also has a complexity of 2. It's either executing statement 1 or 2, so there's one decision point.


```
if (expression) {
	// statement 1
	return something;
} else {
	// statement 2
	return something else;
}
```

Now SonarLint will actually increase the complexity 4! But the number of decision points did not increase.
If you are already inside the else branch, you are _always_ going to execute the return, so there's no decision point.

The cyclomatic complexity is a very useful metric that relates to testability.
The higher the cyclomatic complexity, the more tests you will need to cover all the branches.

Currently, because SonarLint incorrectly counts return statements, you can decrease the complexity of the previous example to 2 by refactoring to:

```
var output;
if (expression) {
	// statement 1
	output = something;
} else {
	// statement 2
	output = something else;
}
return output;
```

Now SonarLint reports the correct complexity (2). However, this refactoring did not decrease the number of decision points and it also did not decrease the effort to unit test all the paths.

With the same reasoning you should also not raise cyclomatic complexity for a `throw` statement (which is currently counted for VB.NET), because it's an unescapable statement.
Only if you put an `if` branch around it, then the if will increase the number of paths, but the throw statement on itself won't.

(If you want to be really puristic on cyclomatic complexity, then return statements should actually decrease cyclomatic complexity, where cyclomatic complexity = number of branch points - number of exit points + 2, but I wouldn't go that far and stick to the simple definition, i.e., branch points + 1)

### Proposal

I removed counting the return statements from the C# implementation. For VB.NET there were even more changes to make.

I hope this PR will be accepted. The McCabe Cyclomatic Complexity is an important and well-known metric for code quality. It would really help if SonarLint follows the definition of this rule correctly, so that code quality experts can speak the same language.